### PR TITLE
Tweak express server settings to function in dev and prod modes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,3 +22,5 @@
 **/values.dev.yaml
 LICENSE
 README.md
+
+./scripts

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "axios": "^1.6.1",
     "chart.js": "^4.4.0",
     "chartjs": "^0.3.24",
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "react": "^18.2.0",
     "react-chartjs-2": "^5.2.0",
     "react-dom": "^18.2.0",
-    "cors": "^2.8.5",
     "prom-client": "^15.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "NODE_ENV=production webpack",
     "cluster": "./scripts/dev_cluster.sh",
-    "dev": "NODE_ENV=development concurrently 'nodemon server/server.js' 'webpack-dev-server --open'",
+    "dev": "NODE_ENV=development EXPRESS_PORT=3010 concurrently 'nodemon server/server.js' 'webpack-dev-server --open'",
     "start": "NODE_ENV=production node server/server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/server/routers/dataRoutes.js
+++ b/server/routers/dataRoutes.js
@@ -3,7 +3,6 @@ const dataRouter = express.Router();
 const dataController = require('../controllers/dataController')
 
 dataRouter.post('/pull', dataController.getData, (req, res) => {
-  console.log(res.locals.metric)
   res.status(200).json(res.locals.metric);
 });
 

--- a/server/server.js
+++ b/server/server.js
@@ -7,16 +7,17 @@ const dataRoutes = require('./routers/dataRoutes')
 const app = express();
 const PORT = process.env.EXPRESS_PORT || 3000;
 
+// baseline middleware setup
 app.use(cors());
 app.use(express.json());
 
+// application routes
 app.use('/api', dataRoutes);
 
 app.use('/', (req, res) => {
   console.log(req)
   res.sendFile(path.join(__dirname, '../src/index.html'));
 })
-
 
 
 app.listen(PORT, () => {

--- a/server/server.js
+++ b/server/server.js
@@ -1,7 +1,6 @@
 const express = require('express');
 const path = require('path');
 const cors = require('cors');
-const axios = require('axios');
 const dataRoutes = require('./routers/dataRoutes')
 
 const app = express();

--- a/server/server.js
+++ b/server/server.js
@@ -10,10 +10,7 @@ const PORT = process.env.EXPRESS_PORT || 3000;
 app.use(cors());
 app.use(express.json());
 
-
-
-app.use('/api', dataRoutes)
-
+app.use('/api', dataRoutes);
 
 app.use('/', (req, res) => {
   console.log(req)
@@ -26,4 +23,4 @@ app.listen(PORT, () => {
   console.log(`Kubernautics listening on http://localhost:${PORT}`);
 });
 
-module.exports = app
+module.exports = app;

--- a/server/server.js
+++ b/server/server.js
@@ -9,12 +9,13 @@ const PORT = process.env.EXPRESS_PORT || 3000;
 // baseline middleware setup
 app.use(cors());
 app.use(express.json());
+app.use(express.static(path.join(__dirname, '../dist')));
 
 // application routes
 app.use('/api', dataRoutes);
 
 app.get('/', (req, res) => {
-  res.sendFile(path.join(__dirname, '../src/index.html'));
+  res.status(200).sendFile('/index.html');
 })
 
 

--- a/server/server.js
+++ b/server/server.js
@@ -5,7 +5,7 @@ const axios = require('axios');
 const dataRoutes = require('./routers/dataRoutes')
 
 const app = express();
-const PORT = 3000;
+const PORT = process.env.EXPRESS_PORT || 3000;
 
 app.use(cors());
 app.use(express.json());

--- a/server/server.js
+++ b/server/server.js
@@ -14,8 +14,7 @@ app.use(express.json());
 // application routes
 app.use('/api', dataRoutes);
 
-app.use('/', (req, res) => {
-  console.log(req)
+app.get('/', (req, res) => {
   res.sendFile(path.join(__dirname, '../src/index.html'));
 })
 

--- a/src/components/MonitoringComponent.jsx
+++ b/src/components/MonitoringComponent.jsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 const MonitoringComponent = () => {
   const fetchData = async () => {
     try {
-      const response = await fetch('/api/pull)', {
+      const response = await fetch('/api/pull', {
         method: 'POST',
       });
       const data = await response.json();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
 		compress: true,
 		port: 8080,
 		proxy: {
-			'/api/**': 'http://localhost:3000',
+			'/api/**': `http://localhost:${process.env.EXPRESS_PORT}`,
 		}
 	},
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,9 @@ module.exports = {
 		})
 	],
 	devServer: {
-		// static: path.join(__dirname, 'dist'),
+		static: {
+			directory: path.join(__dirname, 'dist'),
+		},
 		compress: true,
 		port: 3000,
 		proxy: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ module.exports = {
 	devServer: {
 		// static: path.join(__dirname, 'dist'),
 		compress: true,
-		port: 8080,
+		port: 3000,
 		proxy: {
 			'/api/**': `http://localhost:${process.env.EXPRESS_PORT}`,
 		}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -46,6 +46,7 @@ module.exports = {
 			'/api/**': `http://localhost:${process.env.EXPRESS_PORT}`,
 		}
 	},
+	devtool: 'eval-source-map',
 };
 
 


### PR DESCRIPTION
Key changes:

- Express' port is now assignable by setting the `EXPRESS_PORT` environment variable. If the variable is not set, the server correctly defaults to port `3000`. We currently use this env variable in `package.json` to change the port to `3010` when we run `npm run dev`, so that express gets out of the way and `webpack-dev-server` can occupy port `3000`.
- I ran into an issue while debugging where I would get browser console errors that pointed to JSX lines that had been compiled down by webpack, leaving me unsure of what the error actually was. I enabled source map creation in the webpack config to alleviate this (see the `devtool` property in the webpack conf file).
- I also tested the app in production mode (by running `npm run build; npm start`). Webpack built the app with no issues, but the frontend wasn't being served up. I set up a static route on the express side to make that work correctly.

Beyond that, minor cleanup, when I ran into such things. I tried to be good about leaving small, detailed commits, so there should be meaningful comments for most of the lines I changed explaining what's myself. Overall the changes were pretty tame.

Let me know if you see anything amiss.

We're getting there!

PS: @edli-dot , I accidentally clicked you as a reviewer on this PR, and can't figure out how to undo that. :) I mean, your review is surely welcome, and it's probably neighborly of us to let @matinschams merge into his own feature branch. :upside_down_face: 