### PR TITLE
Configure jest for basic React component testing

### DIFF
--- a/jest.all.config.js
+++ b/jest.all.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   projects: [
     './server/',
-    // './src/',
+    './src/',
   ],
 };

--- a/src/__tests__/ClearCharts.test.js
+++ b/src/__tests__/ClearCharts.test.js
@@ -1,0 +1,11 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import ClearChart from '../components/ClearCharts';
+
+describe ('ClearChart', () => {
+  test('Button should be labelled correctly', () => {
+    render(<ClearChart />);
+    expect(screen.getByText("Reset to Defaults")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/MonitoringComponent.test.js
+++ b/src/__tests__/MonitoringComponent.test.js
@@ -1,4 +1,5 @@
-import React from "react";
+import * as React from 'react';
+
 import MonitoringComponent from "../../src/components/MonitoringComponent";
 
 describe('Monitoring Component', () => {

--- a/src/jest-setup.js
+++ b/src/jest-setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/jest.config.js
+++ b/src/jest.config.js
@@ -1,0 +1,13 @@
+module.exports = {
+  testEnvironment: 'jest-environment-jsdom',
+  setupFilesAfterEnv: [
+    '<rootDir>/jest-setup.js'
+  ],
+  transform: {
+    '\\.jsx?$': 'babel-jest',
+  },
+  // moduleFileExtensions: ["js", "mjs", "cjs", "jsx", "png", "json", "node"],
+  // moduleNameMapper: {
+  //   '\\.(jpg|jpeg|gif|png)': '<rootDir>/__mocks__/fileMock.js',
+  // },
+};


### PR DESCRIPTION
Work is ongoing getting React Router to function correctly in the test environment. With this PR, however, more "vanilla" react components should test correctly if the tests are placed in `src/__tests__`.

One test for `ClearCharts.jsx` is written to prove out the config.