### PR TITLE
Jest Testing: React component unit testing

### DIFF
--- a/src/__tests__/CustomChart.test.js
+++ b/src/__tests__/CustomChart.test.js
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { render } from '@testing-library/react';
+
+import { CustomChart } from '../components/CustomChart';
+
+describe ('CustomChart', () => {
+  test('Should provide a "Reset" button', () => {
+    const { getByRole } = render(<CustomChart />);
+    expect(getByRole('button', { name: 'Reset to Defaults'})).toBeInTheDocument();
+  });
+  test('Should provide an "Add Metric" button', () => {
+    const { getByRole } = render(<CustomChart />);
+    expect(getByRole('button', { name: 'Add Metric'})).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/MonitoringComponent.test.js
+++ b/src/__tests__/MonitoringComponent.test.js
@@ -1,9 +1,0 @@
-import * as React from 'react';
-
-import MonitoringComponent from "../../src/components/MonitoringComponent";
-
-describe('Monitoring Component', () => {
-  test('should run this test', () => {
-    expect(true);
-  });
-});

--- a/src/__tests__/NavBar.test.jsx
+++ b/src/__tests__/NavBar.test.jsx
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { render, screen } from '@testing-library/react';
+
+import NavBar from '../components/NavBar';
+
+describe ('NavBar', () => {
+  test('Renders correctly', () => {
+    render(
+      <MemoryRouter>
+        <NavBar />
+      </MemoryRouter>
+    );
+    expect(screen.getByText("Kubernautics")).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/NavBar.test.jsx
+++ b/src/__tests__/NavBar.test.jsx
@@ -7,6 +7,14 @@ import NavBar from '../components/NavBar';
 describe ('NavBar', () => {
   test('Renders correctly', () => {
     render(
+      // MemoryRouter is used here to stand in for the actual (React-)Router component
+      // used in the app. Some documentation on how to test with/around React Router
+      // can be found here --
+      // https://testing-library.com/docs/example-react-router/ (we use react-router v6)
+      //
+      // These were also helpful to a point, but do note the URL suggests they're for
+      // react-router v5. --
+      // https://v5.reactrouter.com/web/guides/testing
       <MemoryRouter>
         <NavBar />
       </MemoryRouter>

--- a/src/components/MonitoringComponent.jsx
+++ b/src/components/MonitoringComponent.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Line } from 'react-chartjs-2';
 import Chart from 'chart.js/auto'; // -> automatic module import based on the file
-import { enUS } from 'date-fns/esm/locale';
+import { enUS } from 'date-fns/locale';
 import 'chartjs-adapter-date-fns';
 
 const MonitoringComponent = ({ query, range, stepSize }) => {

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
-import nautics from '../../assets/images/nautics';
+// import nautics from '../../assets/images/nautics';
 
 const NavBar = () => {
   return (
     <header className='navBar'>
       <div className='brand'>
-        <img src={nautics} className='logo' />
+        {/* <img src={nautics} className='logo' /> */}
         <h1>Kubernautics</h1>
       </div>
 

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import nautics from '../../assets/images/nautics';
 
-const NavBar = (props) => {
+const NavBar = () => {
   return (
     <header className='navBar'>
       <div className='brand'>


### PR DESCRIPTION
This PR configures jest for unit testing React components, and provides a few base test files. These test suites should be fleshed out, but are enough to confirm the components render and test correctly.

A few items of note --
- Components making use of any React Router functionality require some special handling. `NavBar.test.jsx` provides a basic example for how to successfully render a component with `<Link />` subcomponents inside it for testing. Other use cases might require slightly different techniques; I've also added links to helpful documentation in the comments of that file.
- `<canvas>` elements give some trouble when trying to render for testing. That said, all the `canvas`es we generate are via third-party libraries, so arguably we shouldn't need to unit test those. We can tackle making sure they work as expected with end-to-end testing at a later date.